### PR TITLE
fix: sitemap urls

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,7 +7,7 @@ module.exports = {
   urlMapping: {
     globalPrefix: "/blog",
     entries: {},
-    baseUrl: "https://sharefable.com/",
+    baseUrl: "https://www.sharefable.com/",
   },
   layout: CustomLayout,
   props: {


### PR DESCRIPTION
Change the baseurl from sharefable.com to www.sharefable.com to avoid redirects in sitemap urls